### PR TITLE
refactor: Set host only once

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,9 @@ import (
 
 type Config struct {
 	ID               string
+	Host             string
 	ApiPort          int
+	ApiAddress       string
 	ConsensusHost    string
 	ConsensusPort    int
 	ConsensusAddress string
@@ -15,16 +17,18 @@ type Config struct {
 
 func New() Config {
 	id := flag.String("id", "node_1", "")
+	host := flag.String("host", "localhost", "")
 	apiPort := flag.Int("api-port", 3001, "")
-	consensusHost := flag.String("consensus-host", "localhost", "")
 	consensusPort := flag.Int("consensus-port", 4001, "")
 	flag.Parse()
 
-	consensusAddress := fmt.Sprintf("%s:%v", *consensusHost, *consensusPort)
+	apiAddress := fmt.Sprintf("%s:%v", *host, *apiPort)
+	consensusAddress := fmt.Sprintf("%s:%v", *host, *consensusPort)
 	return Config{
 		ID:               *id,
+		Host:             *host,
 		ApiPort:          *apiPort,
-		ConsensusHost:    *consensusHost,
+		ApiAddress:       apiAddress,
 		ConsensusPort:    *consensusPort,
 		ConsensusAddress: consensusAddress,
 	}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"log"
 	"nubedb/api/middleware"
@@ -12,9 +11,7 @@ import (
 
 func main() {
 	cfg := config.New()
-	apiAddr := fmt.Sprintf("%s:%v", "0.0.0.0", cfg.ApiPort)
-
-	errListen := newApi(cfg).Listen(apiAddr)
+	errListen := newApi(cfg).Listen(cfg.ApiAddress)
 	if errListen != nil {
 		log.Fatalln("api can't be started:", errListen)
 	}


### PR DESCRIPTION
The Api host and the Consensus host is the same host. This PR simplifies it.