### PR TITLE
hotfix: Fix release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,3 +25,5 @@ jobs:
           ldflags: "-w -s"
           md5sum: TRUE
           sha256sum: TRUE
+          retry: 10
+          overwrite: true


### PR DESCRIPTION
Trying to make a release a bug occurs:

`Transport: cannot retry err [stream error: stream ID 1; REFUSED_STREAM; received from peer] after Request.Body was written; define Request.GetBody to avoid this error`

This seems to be related to: https://github.com/wangyoucao577/go-release-action/issues/68

One of the commenters suggest to increase the retry amount and to add an overwrite