### PR TITLE
feat: Check if key exists on delete

### DIFF
--- a/api/route/db.go
+++ b/api/route/db.go
@@ -18,7 +18,7 @@ func (a *ApiCtx) storeGet(fiberCtx *fiber.Ctx) error {
 
 	value, errGet := a.FSM.Get(payload.Key)
 	if errGet != nil {
-		if strings.Contains(strings.ToLower(errGet.Error()), "not found") {
+		if strings.Contains(strings.ToLower(errGet.Error()), "key not found") {
 			return jsonresponse.NotFound(fiberCtx, "key doesn't exist")
 		}
 		return jsonresponse.ServerError(fiberCtx, "couldn't get key from DB: "+errGet.Error())
@@ -55,6 +55,9 @@ func (a *ApiCtx) storeDelete(fiberCtx *fiber.Ctx) error {
 
 	errCluster := consensus.ClusterOperation(a.Consensus, payload, operationType)
 	if errCluster != nil {
+		if strings.Contains(strings.ToLower(errCluster.Error()), "key not found") {
+			return jsonresponse.NotFound(fiberCtx, "key doesn't exist")
+		}
 		return jsonresponse.ServerError(fiberCtx, errCluster.Error())
 	}
 

--- a/consensus/fsm/delete.go
+++ b/consensus/fsm/delete.go
@@ -1,10 +1,33 @@
 package fsm
 
-import "github.com/narvikd/errorskit"
+import (
+	"errors"
+	"github.com/narvikd/errorskit"
+)
 
 func (dbFSM DatabaseFSM) delete(k string) error {
 	txn := dbFSM.db.NewTransaction(true)
 	defer txn.Discard()
+
+	dbResultValue := make([]byte, 0)
+	dbResult, errGet := txn.Get([]byte(k))
+	if errGet != nil {
+		return errGet
+	}
+
+	errDBResultValue := dbResult.Value(func(val []byte) error {
+		dbResultValue = append(dbResultValue, val...)
+		return nil
+	})
+
+	if errDBResultValue != nil {
+		return errDBResultValue
+	}
+
+	if dbResultValue == nil || len(dbResultValue) <= 0 {
+		return errors.New("no result for key")
+	}
+
 	err := txn.Delete([]byte(k))
 	if err != nil {
 		return err

--- a/consensus/fsm/delete.go
+++ b/consensus/fsm/delete.go
@@ -1,7 +1,6 @@
 package fsm
 
 import (
-	"errors"
 	"github.com/narvikd/errorskit"
 )
 
@@ -9,28 +8,14 @@ func (dbFSM DatabaseFSM) delete(k string) error {
 	txn := dbFSM.db.NewTransaction(true)
 	defer txn.Discard()
 
-	dbResultValue := make([]byte, 0)
-	dbResult, errGet := txn.Get([]byte(k))
+	_, errGet := txn.Get([]byte(k))
 	if errGet != nil {
 		return errGet
 	}
 
-	errDBResultValue := dbResult.Value(func(val []byte) error {
-		dbResultValue = append(dbResultValue, val...)
-		return nil
-	})
-
-	if errDBResultValue != nil {
-		return errDBResultValue
-	}
-
-	if dbResultValue == nil || len(dbResultValue) <= 0 {
-		return errors.New("no result for key")
-	}
-
-	err := txn.Delete([]byte(k))
-	if err != nil {
-		return err
+	errDelete := txn.Delete([]byte(k))
+	if errDelete != nil {
+		return errDelete
 	}
 
 	errCommit := txn.Commit()


### PR DESCRIPTION
When a delete is called, it doesn't check in a transaction if the key exists.
It doesn't have any negative effect as explained in https://github.com/narvikd/nubedb/pull/6, but it would be great to indicate that the key doesn't exist.
Refers to issue #1 .