### PR TITLE
refactor: Deprecate bootstrap observer

### DIFF
--- a/api/rest/route/db.go
+++ b/api/rest/route/db.go
@@ -37,7 +37,7 @@ func (a *ApiCtx) storeSet(fiberCtx *fiber.Ctx) error {
 	}
 	payload.Operation = operationType
 
-	errCluster := cluster.Execute(a.Config, a.Node.Consensus, payload)
+	errCluster := cluster.Execute(a.Node.Consensus, payload)
 	if errCluster != nil {
 		return jsonresponse.ServerError(fiberCtx, errCluster.Error())
 	}
@@ -55,7 +55,7 @@ func (a *ApiCtx) storeDelete(fiberCtx *fiber.Ctx) error {
 	}
 	payload.Operation = operationType
 
-	errCluster := cluster.Execute(a.Config, a.Node.Consensus, payload)
+	errCluster := cluster.Execute(a.Node.Consensus, payload)
 	if errCluster != nil {
 		if strings.Contains(strings.ToLower(errCluster.Error()), "key not found") {
 			return jsonresponse.NotFound(fiberCtx, "key doesn't exist")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,7 +19,7 @@ type App struct {
 }
 
 func NewApp(cfg config.Config) *App {
-	node, errConsensus := consensus.New(cfg.CurrentNode.ID, cfg.CurrentNode.ConsensusAddress)
+	node, errConsensus := consensus.New(cfg)
 	if errConsensus != nil {
 		log.Fatalln(errConsensus)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+const (
+	ApiPort       = 3001
+	ConsensusPort = 3002
+	GrpcPort      = 3003
+)
+
 type NodeCfg struct {
 	ID               string
 	ApiPort          int
@@ -20,7 +26,6 @@ type NodeCfg struct {
 
 type Config struct {
 	CurrentNode NodeCfg
-	Nodes       map[string]NodeCfg
 }
 
 func New() (Config, error) {
@@ -35,40 +40,24 @@ func New() (Config, error) {
 		return Config{}, fmt.Errorf("no host found for: %s", currentNodeID)
 	}
 
-	nodes := make(map[string]NodeCfg)
-	for i := 1; i <= 3; i++ {
-		n := fmt.Sprintf("node%v", i)
-		nodes[n] = newNodeCfg(n)
-	}
-
-	currentNode, exist := nodes[currentNodeID]
-	if !exist {
-		return Config{}, fmt.Errorf("current node not found in nodes: %s", currentNodeID)
-	}
-
-	cfg := Config{
-		CurrentNode: currentNode,
-		Nodes:       nodes,
-	}
+	cfg := Config{CurrentNode: NewNodeCfg(currentNodeID)}
 	return cfg, nil
 }
 
-func newNodeCfg(nodeID string) NodeCfg {
-	const (
-		apiPort       = 3001
-		consensusPort = 3002
-		grpcPort      = 3003
-	)
-
+func NewNodeCfg(nodeID string) NodeCfg {
 	return NodeCfg{
 		ID:               nodeID,
-		ApiPort:          apiPort,
-		ApiAddress:       makeAddr(nodeID, apiPort),
-		ConsensusPort:    consensusPort,
-		ConsensusAddress: makeAddr(nodeID, consensusPort),
-		GrpcPort:         grpcPort,
-		GrpcAddress:      makeAddr(nodeID, grpcPort),
+		ApiPort:          ApiPort,
+		ApiAddress:       makeAddr(nodeID, ApiPort),
+		ConsensusPort:    ConsensusPort,
+		ConsensusAddress: makeAddr(nodeID, ConsensusPort),
+		GrpcPort:         GrpcPort,
+		GrpcAddress:      MakeGrpcAddress(nodeID),
 	}
+}
+
+func MakeGrpcAddress(nodeID string) string {
+	return makeAddr(nodeID, GrpcPort)
 }
 
 func makeAddr(host string, port int) string {


### PR DESCRIPTION
This PR sets 3 nodes as bootstrapping nodes in the consensus shared config itself.
If the node set grows, the new nodes are also there, meaning that the list is now managed and shared by all consensus.

Related: https://github.com/narvikd/nubedb/issues/12