### PR TITLE
hotfix: cluster readiness check to fix slow cluster start causing cluster wide race conditions

### DIFF
--- a/cluster/consensus/consensus.go
+++ b/cluster/consensus/consensus.go
@@ -253,7 +253,7 @@ func (n *Node) waitForClusterReadiness() error {
 	)
 	for {
 		currentTry++
-		if currentTry >= maxRetryCount {
+		if currentTry > maxRetryCount {
 			return errors.New("quorum retry max reached")
 		}
 		if n.IsQuorumPossible(true) {

--- a/cluster/consensus/consensus.go
+++ b/cluster/consensus/consensus.go
@@ -244,8 +244,13 @@ func joinNodeToExistingConsensus(nodeID string) error {
 }
 
 func (n *Node) waitForClusterReadiness() {
-	const maxRetryCount = 7
+	const (
+		maxRetryCount = 7
+		sleepTime     = 1 * time.Minute
+	)
+
 	currentTry := 0
+
 	for {
 		currentTry++
 		if currentTry >= maxRetryCount {
@@ -256,6 +261,6 @@ func (n *Node) waitForClusterReadiness() {
 			break
 		}
 		n.logger.Error("it is not possible to reach Quorum due to lack of nodes. Retrying...")
-		time.Sleep(1 * time.Minute)
+		time.Sleep(sleepTime)
 	}
 }


### PR DESCRIPTION
If the number of nodes in the cluster is too big, or the cluster too slow, the system will enter into a race condition in which it thinks it's stuck (because the nodes necessaries are not online).
This PR should add the necessary functionality to prevent that from happening.