### PR TITLE
refactor: Have ability to implement a discover strategy

### DIFF
--- a/api/rest/route/healthcheck.go
+++ b/api/rest/route/healthcheck.go
@@ -19,6 +19,7 @@ func (a *ApiCtx) consensusState(fiberCtx *fiber.Ctx) error {
 	address, id := a.Node.Consensus.LeaderWithID()
 	stats["leader"] = fmt.Sprintf("Address: %s Leader ID: %s", address, id)
 	stats["node_id"] = a.Config.CurrentNode.ID
+	stats["node_host"] = a.Config.CurrentNode.Host
 	stats["is_quorum_possible"] = strconv.FormatBool(a.Node.IsQuorumPossible(false))
 	return jsonresponse.OK(fiberCtx, "consensus state retrieved successfully", stats)
 }

--- a/cluster/consensus/consensus.go
+++ b/cluster/consensus/consensus.go
@@ -80,7 +80,7 @@ func newNode(cfg config.Config) (*Node, error) {
 	dir := path.Join("data", cfg.CurrentNode.ID)
 	storageDir := path.Join(dir, "localdb")
 
-	f, errDB := fsm.New(storageDir, cfg.CurrentNode.FSMPerformanceMode)
+	f, errDB := fsm.New(storageDir, cfg.Cluster.FSMPerformanceMode)
 	if errDB != nil {
 		return nil, errDB
 	}
@@ -244,14 +244,14 @@ func joinNodeToExistingConsensus(nodeID string) error {
 	if errSearchLeader != nil {
 		return errSearchLeader
 	}
-	return cluster.ConsensusJoin(nodeID, config.MakeConsensusAddr(nodeID), config.MakeGrpcAddress(leaderID))
+	return cluster.ConsensusJoin(nodeID, discover.NewConsensusAddr(nodeID), discover.NewGrpcAddress(leaderID))
 }
 
 func newConsensusServerList(nodeID string) []raft.Server {
 	return []raft.Server{
 		{
 			ID:      raft.ServerID(nodeID),
-			Address: raft.ServerAddress(config.MakeConsensusAddr(nodeID)),
+			Address: raft.ServerAddress(discover.NewConsensusAddr(nodeID)),
 		},
 	}
 }

--- a/cluster/consensus/consensus.go
+++ b/cluster/consensus/consensus.go
@@ -257,11 +257,11 @@ func newConsensusServerList(nodeID string) []raft.Server {
 }
 
 func (n *Node) waitForClusterReadiness() error {
-	currentTry := 0
 	const (
 		maxRetryCount = 7
 		sleepTime     = 1 * time.Minute
 	)
+	currentTry := 0
 	for {
 		currentTry++
 		if currentTry > maxRetryCount {

--- a/cluster/consensus/healthcheck.go
+++ b/cluster/consensus/healthcheck.go
@@ -3,7 +3,7 @@ package consensus
 import (
 	"github.com/hashicorp/raft"
 	"math"
-	"nubedb/cluster"
+	"nubedb/discover"
 	"strconv"
 )
 
@@ -71,7 +71,7 @@ func (n *Node) IsQuorumPossible(preAlert bool) bool {
 	if preAlert {
 		necessaryForQuorum = math.Round(consensusNodes * percentile)
 	}
-	onlineNodes := len(cluster.GetAliveNodes(n.Consensus, n.ID))
+	onlineNodes := len(discover.SearchAliveNodes(n.Consensus, n.ID))
 
 	return float64(onlineNodes) >= necessaryForQuorum
 }

--- a/cluster/consensus/observer.go
+++ b/cluster/consensus/observer.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"nubedb/cluster"
 	"nubedb/discover"
-	"nubedb/internal/config"
 	"time"
 )
 
@@ -108,7 +107,7 @@ func (n *Node) registerRequestVoteRequestChan() {
 					idRequester,
 				)
 				n.logger.Warn(msgWarn)
-				err := cluster.RequestNodeReinstall(config.MakeGrpcAddress(idRequester))
+				err := cluster.RequestNodeReinstall(discover.NewGrpcAddress(idRequester))
 				if err != nil {
 					msgErr := errorskit.Wrap(err, "couldn't reinstall foreign node")
 					n.logger.Error(msgErr.Error())
@@ -156,7 +155,7 @@ func (n *Node) ReinstallNode() {
 	if errSearchLeader != nil {
 		errorskit.FatalWrap(errSearchLeader, errPanic+"couldn't search for leader")
 	}
-	leaderGrpcAddress := config.MakeGrpcAddress(leader)
+	leaderGrpcAddress := discover.NewGrpcAddress(leader)
 
 	errConsensusRemove := cluster.ConsensusRemove(n.ID, leaderGrpcAddress)
 	if errConsensusRemove != nil {

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -1,0 +1,46 @@
+package discover
+
+import (
+	"errors"
+	"github.com/hashicorp/raft"
+	"nubedb/discover/mdnsdiscover"
+	"nubedb/internal/config"
+	"nubedb/pkg/ipkit"
+)
+
+var mode = config.DiscoverDefault
+
+func SetMode(m string) error {
+	if mode != config.DiscoverDefault && mode != config.DiscoverNubeRegistry {
+		return errors.New("discover mode not recognized")
+	}
+	mode = m
+	return nil
+}
+
+func GetAliveNodes(consensus *raft.Raft, currentNodeID string) []raft.Server {
+	switch mode {
+	case config.DiscoverDefault:
+		return mdnsdiscover.GetAliveNodes(consensus, currentNodeID)
+	default:
+		return []raft.Server{}
+	}
+}
+
+func NewConsensusAddr(nodeHost string) string {
+	switch mode {
+	case config.DiscoverDefault:
+		return ipkit.NewAddr(nodeHost, config.ConsensusPort)
+	default:
+		return ""
+	}
+}
+
+func NewGrpcAddress(nodeHost string) string {
+	switch mode {
+	case config.DiscoverDefault:
+		return ipkit.NewAddr(nodeHost, config.GrpcPort)
+	default:
+		return ""
+	}
+}

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -18,12 +18,28 @@ func SetMode(m string) error {
 	return nil
 }
 
-func GetAliveNodes(consensus *raft.Raft, currentNodeID string) []raft.Server {
+// SearchAliveNodes will skip currentNodeID.
+func SearchAliveNodes(consensus *raft.Raft, currentNodeID string) []raft.Server {
 	switch mode {
 	case config.DiscoverDefault:
-		return mdnsdiscover.GetAliveNodes(consensus, currentNodeID)
+		return mdnsdiscover.SearchAliveNodes(consensus, currentNodeID)
 	default:
 		return []raft.Server{}
+	}
+}
+
+// SearchLeader will return an error if a leader is not found,
+// since it skips the current node and this could be a leader.
+//
+// Because it skips the current node, it will still return an error.
+//
+// This is done this way to ensure this function is never called to do gRPC operations in itself.
+func SearchLeader(currentNode string) (string, error) {
+	switch mode {
+	case config.DiscoverDefault:
+		return mdnsdiscover.SearchLeader(currentNode)
+	default:
+		return "", nil
 	}
 }
 

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -11,7 +11,7 @@ import (
 var mode = config.DiscoverDefault
 
 func SetMode(m string) error {
-	if mode != config.DiscoverDefault && mode != config.DiscoverNubeRegistry {
+	if mode != config.DiscoverDefault {
 		return errors.New("discover mode not recognized")
 	}
 	mode = m

--- a/discover/mdnsdiscover/mdnsdiscover.go
+++ b/discover/mdnsdiscover/mdnsdiscover.go
@@ -67,7 +67,9 @@ func getIP(nodeID string) (net.IP, error) {
 // SearchLeader will return an error if a leader is not found,
 // since it skips the current node and this could be a leader.
 //
-// If the current node is as leader, it will still return an error
+// Because it skips the current node, it will still return an error.
+//
+// This is done this way to ensure this function is never called to do gRPC operations in itself.
 func SearchLeader(currentNode string) (string, error) {
 	nodes, errNodes := searchNodes(currentNode)
 	if errNodes != nil {
@@ -171,7 +173,8 @@ func isLeader(addr string) (bool, error) {
 	return res.IsLeader, nil
 }
 
-func GetAliveNodes(consensus *raft.Raft, currentNodeID string) []raft.Server {
+// SearchAliveNodes will skip currentNodeID.
+func SearchAliveNodes(consensus *raft.Raft, currentNodeID string) []raft.Server {
 	const timeout = 300 * time.Millisecond
 	var alive []raft.Server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,15 @@ services:
       - ./data:/app/data
 #    environment:
 #      - FSM_PERFORMANCE=true
+#      - DISCOVER_STRATEGY=default
     restart: on-failure
   node:
     image: narvikd/nubedb:latest
     volumes:
       - ./data:/app/data
-    environment:
-      - FSM_PERFORMANCE=true
+#    environment:
+#      - FSM_PERFORMANCE=true
+#      - DISCOVER_STRATEGY=default
     restart: on-failure
     depends_on:
       - bootstrap-node

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:latest
 ENV FSM_PERFORMANCE ""
+ENV DISCOVER_STRATEGY ""
 WORKDIR /app
 COPY nubedb .
 RUN mkdir /app/data

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/narvikd/fiberparser"
 	"log"
 	"nubedb/cluster/consensus"
+	"nubedb/discover"
 	"nubedb/internal/config"
 	"time"
 )
@@ -19,6 +20,11 @@ type App struct {
 }
 
 func NewApp(cfg config.Config) *App {
+	errDiscover := discover.SetMode(cfg.Cluster.DiscoverStrategy)
+	if errDiscover != nil {
+		log.Fatalln(errDiscover)
+	}
+
 	node, errConsensus := consensus.New(cfg)
 	if errConsensus != nil {
 		log.Fatalln(errConsensus)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,11 +11,10 @@ import (
 )
 
 const (
-	ApiPort              = 3001
-	ConsensusPort        = 3002
-	GrpcPort             = 3003
-	DiscoverDefault      = "default"
-	DiscoverNubeRegistry = "nube_registry"
+	ApiPort         = 3001
+	ConsensusPort   = 3002
+	GrpcPort        = 3003
+	DiscoverDefault = "default"
 )
 
 type Config struct {
@@ -72,16 +71,12 @@ func newNodeID() (string, error) {
 }
 
 func newClusterCfg() Cluster {
-	discoverStrategy := strings.ToLower(os.Getenv("DISCOVER_STRATEGY"))
+	//discoverStrategy := strings.ToLower(os.Getenv("DISCOVER_STRATEGY"))
 	fsmPerformance := strings.ToLower(os.Getenv("FSM_PERFORMANCE"))
 
 	clusterCfg := Cluster{
 		FSMPerformanceMode: fsmPerformance == "true",
 		DiscoverStrategy:   DiscoverDefault,
-	}
-
-	if discoverStrategy == DiscoverNubeRegistry {
-		clusterCfg.DiscoverStrategy = DiscoverNubeRegistry
 	}
 
 	return clusterCfg

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"nubedb/api/proto/protoserver"
 	"nubedb/api/rest/middleware"
 	"nubedb/api/rest/route"
-	"nubedb/discover"
+	"nubedb/discover/mdnsdiscover"
 	"nubedb/internal/app"
 	"nubedb/internal/config"
 	"runtime"
@@ -43,11 +43,13 @@ func start(a *app.App) {
 		startApiProto(a)
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		discover.ServeAndBlock(a.Config.CurrentNode.ID, 8001)
-	}()
+	if a.Config.Cluster.DiscoverStrategy == config.DiscoverDefault {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mdnsdiscover.ServeAndBlock(a.Config.CurrentNode.Host, 8001)
+		}()
+	}
 
 	wg.Wait()
 }

--- a/pkg/ipkit/ipkit.go
+++ b/pkg/ipkit/ipkit.go
@@ -1,0 +1,7 @@
+package ipkit
+
+import "fmt"
+
+func NewAddr(nodeID string, port int) string {
+	return fmt.Sprintf("%s:%v", nodeID, port)
+}


### PR DESCRIPTION
Right now the cluster is using its internal mDNS discover. It would be great if it can use more discover modes.
This PR refactors the code to be able to do so.